### PR TITLE
Fix missing generateStaticParams for export

### DIFF
--- a/app/blog/[id]/layout.tsx
+++ b/app/blog/[id]/layout.tsx
@@ -1,0 +1,16 @@
+import { blogPosts } from '@/lib/data/projects';
+
+// Generate static params for all blog post IDs
+export async function generateStaticParams() {
+  return blogPosts.map((post) => ({
+    id: post.id.toString(),
+  }));
+}
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/projects/[id]/layout.tsx
+++ b/app/projects/[id]/layout.tsx
@@ -1,0 +1,16 @@
+import { projects } from '@/lib/data/projects';
+
+// Generate static params for all project IDs
+export async function generateStaticParams() {
+  return projects.map((project) => ({
+    id: project.id.toString(),
+  }));
+}
+
+export default function ProjectLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -8,7 +8,7 @@ import { ScrollReveal } from '@/components/animations/ScrollReveal';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Progress } from '@/components/ui/progress';
+// import { Progress } from '@/components/ui/progress';
 import { projects } from '@/lib/data/projects';
 
 // Extended project data for detailed view
@@ -183,7 +183,12 @@ export default function ProjectDetail() {
                   {project.progress}%
                 </div>
                 <div className="text-gray-600">Progress</div>
-                <Progress value={project.progress} className="mt-2" />
+                <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
+                  <div 
+                    className="bg-emerald-600 h-2 rounded-full transition-all" 
+                    style={{ width: `${project.progress}%` }}
+                  ></div>
+                </div>
               </div>
             </ScrollReveal>
             


### PR DESCRIPTION
Add `generateStaticParams` to dynamic routes and replace a problematic UI component to enable static export.

The Next.js `output: 'export'` configuration requires `generateStaticParams()` for dynamic routes like `/projects/[id]` and `/blog/[id]` to pre-generate static paths at build time. A build error related to the `Progress` component also necessitated its replacement with a custom CSS solution.

---
<a href="https://cursor.com/background-agent?bcId=bc-82c8fef8-d9c0-4a41-a346-df1410229417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82c8fef8-d9c0-4a41-a346-df1410229417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

